### PR TITLE
fix: check scroll-bar-model before disable it

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -29,10 +29,10 @@
 (setq inhibit-compacting-font-caches t)
 
 ;; Disables unused UI Elements
-(menu-bar-mode -1)
-(scroll-bar-mode -1)
-(tool-bar-mode -1)
-(tooltip-mode -1)
+(if (fboundp 'menu-bar-mode) (menu-bar-mode -1))
+(if (fboundp 'scroll-bar-mode) (scroll-bar-mode -1))
+(if (fboundp 'tool-bar-mode) (tool-bar-mode -1))
+(if (fboundp 'tooltip-mode) (tooltip-mode -1))
 
 ;; Resizing the Emacs frame can be a terribly expensive part of changing the
 ;; font. By inhibiting this, we easily halve startup times with fonts that are


### PR DESCRIPTION
I'm running an emacs compiled with X support. So there is no `scroll-bar-mode` at all..