### PR TITLE
fix typo in webjump youtube string

### DIFF
--- a/init.el
+++ b/init.el
@@ -1708,7 +1708,7 @@ and restart Flymake to apply the changes."
   (webjump-sites
    '(("DuckDuckGo" . [simple-query "www.duckduckgo.com" "www.duckduckgo.com/?q=" ""])
      ("Google" . [simple-query "www.google.com" "www.google.com/search?q=" ""])
-     ("YouTube" . [simple-query "www.youtube.com/feed/subscriptions" "www.youtube.com/rnesults?search_query=" ""])
+     ("YouTube" . [simple-query "www.youtube.com/feed/subscriptions" "www.youtube.com/results?search_query=" ""])
      ("ChatGPT" . [simple-query "https://chatgpt.com" "https://chatgpt.com/?q=" ""]))))
 
 


### PR DESCRIPTION
Change a typo in:
```;;; WEBJUMP
("YouTube" . [simple-query "www.youtube.com/feed/subscriptions" "www.youtube.com/rnesults?search_query=" ""])```

from rnsults to results

Not big deal but is fixed.
  