### PR TITLE
Simplify frame-title-format

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -86,8 +86,7 @@ If reset values are nil, nothing is reset."
       '(:eval
         (let ((project (project-current)))
           (if project
-              (concat "Emacs - [p] "
-                      (file-name-nondirectory (directory-file-name (project-root project))))
+              (concat "Emacs - [p] " (project-name project))
               (concat "Emacs - " (buffer-name))))))
 
 (when (eq system-type 'darwin)


### PR DESCRIPTION
A small refactor to make use of `project-name`. 

Bit shorter and clearer to read at a glance.